### PR TITLE
Add initial capacities for brick vecs

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -270,7 +270,7 @@ impl<R: Read> SaveReader<R> {
         let material_count = cmp::max(header2.materials.len(), 2);
         let physical_material_count = cmp::max(header2.physical_materials.len(), 2);
 
-        let mut bricks = vec![];
+        let mut bricks = Vec::with_capacity(header1.brick_count as usize);
         let mut components = HashMap::new();
 
         // loop over each brick

--- a/src/read.rs
+++ b/src/read.rs
@@ -379,12 +379,8 @@ impl<R: Read> SaveReader<R> {
             bricks.push(brick);
         }
 
+        bricks.shrink_to_fit();
         let brick_count = cmp::max(bricks.len(), 2);
-
-        // if we read a different amount of bricks than stated in header, correct possible overallocation
-        if bricks.len() != header1.brick_count as usize {
-            bricks.shrink_to_fit();
-        }
 
         // components
         if self.version >= 8 {

--- a/src/read.rs
+++ b/src/read.rs
@@ -271,7 +271,7 @@ impl<R: Read> SaveReader<R> {
         let physical_material_count = cmp::max(header2.physical_materials.len(), 2);
 
         let inital_bricks_capacity = cmp::min(header1.brick_count as usize, 10_000_000);
-        let mut bricks = Vec::with_capacity(initial_brick_alloc);
+        let mut bricks = Vec::with_capacity(inital_bricks_capacity);
         let mut components = HashMap::new();
 
         // loop over each brick

--- a/src/read.rs
+++ b/src/read.rs
@@ -270,7 +270,8 @@ impl<R: Read> SaveReader<R> {
         let material_count = cmp::max(header2.materials.len(), 2);
         let physical_material_count = cmp::max(header2.physical_materials.len(), 2);
 
-        let mut bricks = Vec::with_capacity(header1.brick_count as usize);
+        let inital_bricks_capacity = cmp::min(header1.brick_count as usize, 10_000_000);
+        let mut bricks = Vec::with_capacity(initial_brick_alloc);
         let mut components = HashMap::new();
 
         // loop over each brick
@@ -379,6 +380,11 @@ impl<R: Read> SaveReader<R> {
         }
 
         let brick_count = cmp::max(bricks.len(), 2);
+
+        // if we read a different amount of bricks than stated in header, correct possible overallocation
+        if bricks.len() != header1.brick_count as usize {
+            bricks.shrink_to_fit();
+        }
 
         // components
         if self.version >= 8 {

--- a/src/write.rs
+++ b/src/write.rs
@@ -17,6 +17,11 @@ use crate::{
     MAGIC_BYTES, SAVE_VERSION,
 };
 
+// bytes per brick used for initial allocation for brick bit vector
+// this is based on the minimum bits required to store a brick
+// the minimum bits required is 52, but we round up to 64 for reduced allocations in realistic cases
+const NAIVE_BYTES_PER_BRICK: usize = 8;
+
 /// A write error.
 #[derive(Error, Debug)]
 pub enum WriteError {
@@ -143,7 +148,7 @@ impl<W: Write> SaveWriter<W> {
 
         // write bricks and components
         {
-            let mut vec = Vec::with_capacity(self.data.bricks.len() * 8);
+            let mut vec = Vec::with_capacity(self.data.bricks.len() * NAIVE_BYTES_PER_BRICK);
             let mut bits = BitWriter::endian(&mut vec, bitstream_io::LittleEndian);
 
             let mut component_bricks: HashMap<String, Vec<(u32, HashMap<String, UnrealType>)>> =

--- a/src/write.rs
+++ b/src/write.rs
@@ -143,7 +143,7 @@ impl<W: Write> SaveWriter<W> {
 
         // write bricks and components
         {
-            let mut vec = vec![];
+            let mut vec = Vec::with_capacity(self.data.bricks.len() * 8);
             let mut bits = BitWriter::endian(&mut vec, bitstream_io::LittleEndian);
 
             let mut component_bricks: HashMap<String, Vec<(u32, HashMap<String, UnrealType>)>> =


### PR DESCRIPTION
Slightly improve performance by avoiding re-allocations during building of brick vectors.

8 bytes was chosen as the most appropriate for the bit brick vector based on following consideration for minimum bits needed to represent a brick in save version 10. The minimum required is 7 bytes per brick in the case where all "palettes" are 1 or 2 values at most and where positions are small and bricks are not procedural. 8 bytes is a better middle ground for realistic use cases and roundness.

```
minimum bit brick
asset index - 1
brick size - 1 (not procedural)
position - 24 (0, 0, 0)
orientation - 5
collision bits - 4
visibility - 1
material index - 1
physical index - 1
intensity - 4
color - 2 (small palette)
owner - 8

total - 52 bits
```

possible pitfall is if a save file was maliciously constructed to have a max value brick count it would over allocate when reading, but this should not be a concern for brick building files.