### PR TITLE
Proper save time handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 [dependencies]
 bitstream-io = "1.1.0"
 byteorder = "1.4.3"
+chrono = "0.4"
 flate2 = "1.0"
 lazy_static = "1.4.0"
 num_enum = "0.5.1"
@@ -24,5 +25,5 @@ serde_json = "1.0"
 
 [features]
 default = ["util"]
-serialize = ["serde", "serde_repr", "uuid/serde"]
+serialize = ["serde", "serde_repr", "uuid/serde", "chrono/serde"]
 util = []

--- a/src/ext/read.rs
+++ b/src/ext/read.rs
@@ -5,6 +5,7 @@ use std::{
 
 use bitstream_io::BitRead;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
+use chrono::{prelude::*, Duration};
 use uuid::Uuid;
 
 use crate::save::{Color, UnrealType};
@@ -48,6 +49,12 @@ pub trait ReadExt: Read {
         let mut bytes = [0u8; 16];
         BigEndian::write_u32_into(&le_bytes, &mut bytes);
         Ok(Uuid::from_bytes(bytes))
+    }
+
+    fn read_datetime(&mut self) -> Result<DateTime<Utc>> {
+        let ticks = self.read_i64::<LittleEndian>()?;
+        let epoch = Utc.with_ymd_and_hms(1, 1, 1, 0, 0, 0).unwrap();
+        Ok(epoch + Duration::microseconds(ticks / 10) + Duration::nanoseconds((ticks % 10) * 100))
     }
 
     fn read_array<F, T>(&mut self, mut operation: F) -> Result<Vec<T>>

--- a/src/read.rs
+++ b/src/read.rs
@@ -9,7 +9,6 @@ use std::{
 
 use bitstream_io::{BitRead, BitReader};
 use byteorder::{LittleEndian, ReadBytesExt};
-use chrono::{Duration, LocalResult, TimeZone, Utc};
 use flate2::read::ZlibDecoder;
 use thiserror::Error;
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -9,6 +9,7 @@ use std::{
 
 use bitstream_io::{BitRead, BitReader};
 use byteorder::{LittleEndian, ReadBytesExt};
+use chrono::{Duration, LocalResult, TimeZone, Utc};
 use flate2::read::ZlibDecoder;
 use thiserror::Error;
 
@@ -112,9 +113,7 @@ impl<R: Read> SaveReader<R> {
         //         else: not provided
         let save_time = match self.version {
             _ if self.version >= 4 => {
-                let mut bytes = [0u8; 8]; // todo: figure out how to parse this
-                cursor.read_exact(&mut bytes)?;
-                Some(bytes)
+                cursor.read_datetime().ok()
             }
             _ => None,
         };
@@ -134,7 +133,7 @@ impl<R: Read> SaveReader<R> {
             },
             description,
             host,
-            save_time: save_time.unwrap_or([0u8; 8]),
+            save_time,
             brick_count,
         })
     }

--- a/src/save.rs
+++ b/src/save.rs
@@ -5,9 +5,10 @@ use std::hash::{Hash, Hasher};
 use std::io::Read;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use chrono::{DateTime, Utc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use uuid::Uuid;
+
+pub use chrono::{DateTime, Utc};
+pub use uuid::Uuid;
 
 #[cfg(feature = "serialize")]
 use {

--- a/src/save.rs
+++ b/src/save.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::io::Read;
 
 use byteorder::{LittleEndian, ReadBytesExt};
+use chrono::{DateTime, Utc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use uuid::Uuid;
 
@@ -96,8 +97,7 @@ pub struct Header1 {
     pub host: Option<User>,
 
     /// The save time of the save.
-    #[cfg_attr(feature = "serialize", serde(skip))]
-    pub save_time: [u8; 8],
+    pub save_time: Option<DateTime<Utc>>,
 
     /// The number of bricks in the save.
     pub brick_count: u32,
@@ -110,7 +110,7 @@ impl Default for Header1 {
             description: String::new(),
             author: User::default(),
             host: None,
-            save_time: [0u8; 8],
+            save_time: None,
             brick_count: 0,
         }
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -88,7 +88,7 @@ impl<W: Write> SaveWriter<W> {
             w.write_string(host.name)?;
             w.write_uuid(host.id)?;
 
-            w.write_all(&self.data.header1.save_time)?;
+            w.write_datetime(self.data.header1.save_time)?;
             w.write_i32::<LittleEndian>(self.data.bricks.len() as i32)?;
 
             write_compressed(&mut self.writer, w, self.compressed)?;


### PR DESCRIPTION
Finally resolve the TODO for reading save time

- use `chrono::DateTime` for parsed save time
- if save does not have a time, use current time when writing

Result of `read_json` example
```json
{
  "version":10,
  "game_version":6781,
  "map":"Plate",
  "description":"",
  "author":{
    "name":"x",
    "id":"3f5108a0-c929-4e77-a115-21f65096887b"
  },
  "host":{
    "name":"x",
    "id":"3f5108a0-c929-4e77-a115-21f65096887b"
  },
  "save_time":"2021-07-10T22:22:49.135Z",
  ...
}
```